### PR TITLE
implement the correct property handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Web sockets are considered as overengineering for this purpose. But if you are i
 ----
 
 ## TODO
- - Implement and test the property hierarchy (VM arguments, user home, ours)
  - Implement checks for invalid configurations
  - Improve documentation
  - Is it possible to encrypt/decrypt the messages?

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Web sockets are considered as overengineering for this purpose. But if you are i
 ----
 
 ## TODO
- - Rename properties with the package prefix, to be sure they do not conflict with other system properties
  - Implement and test the property hierarchy (VM arguments, user home, ours)
  - Implement checks for invalid configurations
  - Improve documentation

--- a/src/main/java/st/extreme/klingklong/EndpointImpl.java
+++ b/src/main/java/st/extreme/klingklong/EndpointImpl.java
@@ -8,6 +8,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 
+import st.extreme.klingklong.util.PropertyLoader;
+
 /**
  * Implementation of an endpoint.
  */
@@ -19,6 +21,10 @@ public class EndpointImpl implements Endpoint {
 
   private Receiver receiver;
   private Sender sender;
+
+  static {
+    PropertyLoader.loadProperties();
+  }
 
   public EndpointImpl() {
     messageListeners = new HashSet<>();
@@ -35,7 +41,7 @@ public class EndpointImpl implements Endpoint {
 
   @Override
   final public void connect() throws ConnectionException {
-    honk(COSY, "endpoint is connecting ...");
+    honk(HOT, "endpoint is connecting ...");
     receiver.start();
     sender.start();
     try {

--- a/src/main/java/st/extreme/klingklong/ReceiverImpl.java
+++ b/src/main/java/st/extreme/klingklong/ReceiverImpl.java
@@ -1,7 +1,6 @@
 package st.extreme.klingklong;
 
 import static st.extreme.klingklong.util.Horn.honk;
-import static st.extreme.klingklong.util.Temperature.COSY;
 import static st.extreme.klingklong.util.Temperature.HOT;
 
 import java.io.BufferedReader;
@@ -40,10 +39,10 @@ public class ReceiverImpl extends Thread implements Receiver {
         }
       }
     } catch (IOException e) {
-      honk(COSY, "Exception caught when trying to listen on port " + listeningPort + " or listening for a connection");
+      honk(HOT, "Exception caught when trying to listen on port " + listeningPort + " or listening for a connection");
       e.printStackTrace();
     }
-    honk(COSY, "receiver thread is terminating now");
+    honk(HOT, "receiver thread is terminating now");
     readSemaphore.release();
   }
 

--- a/src/main/java/st/extreme/klingklong/SenderImpl.java
+++ b/src/main/java/st/extreme/klingklong/SenderImpl.java
@@ -2,6 +2,7 @@ package st.extreme.klingklong;
 
 import static st.extreme.klingklong.util.Horn.honk;
 import static st.extreme.klingklong.util.Temperature.COSY;
+import static st.extreme.klingklong.util.Temperature.HOT;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -44,7 +45,7 @@ final class SenderImpl extends Thread implements Sender {
       honk(COSY, String.format("connection error with remote host %s", remoteHost.getHostName()));
       e.printStackTrace();
     }
-    honk(COSY, "sender thread is terminating now");
+    honk(HOT, "sender thread is terminating now");
     closedSemaphore.release();
   }
 

--- a/src/main/java/st/extreme/klingklong/demo/JVM1.java
+++ b/src/main/java/st/extreme/klingklong/demo/JVM1.java
@@ -1,8 +1,5 @@
 package st.extreme.klingklong.demo;
 
-import static st.extreme.klingklong.util.Horn.honk;
-import static st.extreme.klingklong.util.Temperature.COSY;
-
 import st.extreme.klingklong.Type;
 
 public class JVM1 {
@@ -22,7 +19,6 @@ public class JVM1 {
    * @return the exit code (0 = success)
    */
   public static int work() {
-    honk(COSY, "starting worker on JVM 1");
     JVMWorker worker = new JVMWorker(Type.KLING);
     try {
       worker.workAndCommunicate();

--- a/src/main/java/st/extreme/klingklong/demo/JVM2.java
+++ b/src/main/java/st/extreme/klingklong/demo/JVM2.java
@@ -1,8 +1,5 @@
 package st.extreme.klingklong.demo;
 
-import static st.extreme.klingklong.util.Horn.honk;
-import static st.extreme.klingklong.util.Temperature.COSY;
-
 import st.extreme.klingklong.Type;
 
 public class JVM2 {
@@ -22,7 +19,6 @@ public class JVM2 {
    * @return the exit code (0 = success)
    */
   public static int work() {
-    honk(COSY, "starting worker on JVM 2");
     JVMWorker worker = new JVMWorker(Type.KLONG);
     try {
       worker.workAndCommunicate();

--- a/src/main/java/st/extreme/klingklong/demo/JVMWorker.java
+++ b/src/main/java/st/extreme/klingklong/demo/JVMWorker.java
@@ -63,11 +63,11 @@ public class JVMWorker implements MessageListener {
     final Endpoint endpoint;
     switch (type) {
     case KLING:
-      honk(COSY, "creating kling");
+      honk(COSY, "creating kling for JVM worker");
       endpoint = Kling.create();
       break;
     case KLONG:
-      honk(COSY, "creating klong");
+      honk(COSY, "creating klong for JVM worker");
       endpoint = Klong.create();
       break;
     default:

--- a/src/main/java/st/extreme/klingklong/demo/JVMWorker.java
+++ b/src/main/java/st/extreme/klingklong/demo/JVMWorker.java
@@ -51,11 +51,11 @@ public class JVMWorker implements MessageListener {
       if (isRemoteListening.get()) {
         endpoint.send("My work is done soon");
       }
-      TimeUnit.SECONDS.sleep(1);
+      TimeUnit.SECONDS.sleep(2);
       if (isRemoteListening.get()) {
         endpoint.send(STOP_MESSAGE);
       }
-      TimeUnit.MILLISECONDS.sleep(500);
+      TimeUnit.SECONDS.sleep(1);
     }
   }
 
@@ -78,12 +78,7 @@ public class JVMWorker implements MessageListener {
 
   private void workOneUnit() throws InterruptedException {
     workCount.incrementAndGet();
-    double rand = Math.random();
-    if (rand <= 0.5) {
-      TimeUnit.SECONDS.sleep(1);
-    } else {
-      TimeUnit.SECONDS.sleep(2);
-    }
+    TimeUnit.SECONDS.sleep(1);
   }
 
 }

--- a/src/main/java/st/extreme/klingklong/util/Horn.java
+++ b/src/main/java/st/extreme/klingklong/util/Horn.java
@@ -1,5 +1,7 @@
 package st.extreme.klingklong.util;
 
+import static st.extreme.klingklong.util.PropertyLoader.TEMPERATURE_PROPERTY_NAME;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -11,6 +13,7 @@ public final class Horn {
     LOGGER = Logger.getLogger(Horn.class.getName());
     // set our formatter on the console handler of the root logger
     Logger.getLogger("").getHandlers()[0].setFormatter(new HornFormatter());
+    PropertyLoader.loadProperties();
   }
 
   public static void honk(Temperature temperature, String message) {
@@ -34,7 +37,7 @@ public final class Horn {
   }
 
   static Temperature systemTemperature() {
-    return Temperature.valueOf(System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name()));
+    return Temperature.valueOf(System.getProperty(TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name()));
   }
 
   private static void internalLog(Level level, String message, Throwable throwable) {

--- a/src/main/java/st/extreme/klingklong/util/Horn.java
+++ b/src/main/java/st/extreme/klingklong/util/Horn.java
@@ -1,14 +1,9 @@
 package st.extreme.klingklong.util;
 
-import java.io.InputStream;
-import java.util.Properties;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public final class Horn {
-
-  public static final String TEMPERATURE_PROPERTY_NAME = "st.extreme.klingklong.horn.temperature";
 
   private static final Logger LOGGER;
 
@@ -16,7 +11,6 @@ public final class Horn {
     LOGGER = Logger.getLogger(Horn.class.getName());
     // set our formatter on the console handler of the root logger
     Logger.getLogger("").getHandlers()[0].setFormatter(new HornFormatter());
-    loadProperties();
   }
 
   public static void honk(Temperature temperature, String message) {
@@ -39,31 +33,8 @@ public final class Horn {
     }
   }
 
-  static void loadProperties() {
-    Properties properties = new Properties();
-    try (InputStream propertiesStream = Horn.class.getResourceAsStream("/klingklong.properties")) {
-      properties.load(propertiesStream);
-    } catch (Exception e) {
-      honk(Temperature.HOT, "unable to load klinklong.properties", e);
-    }
-
-    Set<Object> keys = properties.keySet();
-    for (Object object : keys) {
-      String key = (String) object;
-      setSystemProperty(key, properties.getProperty(key));
-    }
-  }
-
-  static void setSystemProperty(String propertyName, String propertyValue) {
-    // if the system property is already set, do not overwrite it
-    String actualValue = System.getProperty(propertyName);
-    if (actualValue == null) {
-      System.setProperty(propertyName, propertyValue);
-    }
-  }
-
   static Temperature systemTemperature() {
-    return Temperature.valueOf(System.getProperty(TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name()));
+    return Temperature.valueOf(System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name()));
   }
 
   private static void internalLog(Level level, String message, Throwable throwable) {

--- a/src/main/java/st/extreme/klingklong/util/Horn.java
+++ b/src/main/java/st/extreme/klingklong/util/Horn.java
@@ -50,7 +50,15 @@ public final class Horn {
     Set<Object> keys = properties.keySet();
     for (Object object : keys) {
       String key = (String) object;
-      System.setProperty(key, properties.getProperty(key));
+      setSystemProperty(key, properties.getProperty(key));
+    }
+  }
+
+  static void setSystemProperty(String propertyName, String propertyValue) {
+    // if the system property is already set, do not overwrite it
+    String actualValue = System.getProperty(propertyName);
+    if (actualValue == null) {
+      System.setProperty(propertyName, propertyValue);
     }
   }
 

--- a/src/main/java/st/extreme/klingklong/util/Horn.java
+++ b/src/main/java/st/extreme/klingklong/util/Horn.java
@@ -8,7 +8,7 @@ import java.util.logging.Logger;
 
 public final class Horn {
 
-  public static final String TEMPERATURE_PROPERTY_NAME = "klingklong.horn.temperature";
+  public static final String TEMPERATURE_PROPERTY_NAME = "st.extreme.klingklong.horn.temperature";
 
   private static final Logger LOGGER;
 

--- a/src/main/java/st/extreme/klingklong/util/PropertyLoader.java
+++ b/src/main/java/st/extreme/klingklong/util/PropertyLoader.java
@@ -1,34 +1,33 @@
 package st.extreme.klingklong.util;
 
 import static st.extreme.klingklong.util.Horn.honk;
+import static st.extreme.klingklong.util.Temperature.HOT;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class PropertyLoader {
 
+  // property names
   public static final String TEMPERATURE_PROPERTY_NAME = "st.extreme.klingklong.horn.temperature";
 
+  // property file names
+  public static final String BUILTIN_PROPERTY_FILE_NAME = "klingklong.properties";
+  private static final String HOME_PROPERTY_FiLE_NAME = ".st.extreme.klingklong.properties";
 
-  static {
-    loadProperties();
-  }
-
-  // TODO: handle properties in user.home
+  private static AtomicBoolean loaded = new AtomicBoolean(false);
 
   public static void loadProperties() {
-    Properties properties = new Properties();
-    try (InputStream propertiesStream = Horn.class.getResourceAsStream("/klingklong.properties")) {
-      properties.load(propertiesStream);
-    } catch (Exception e) {
-      honk(Temperature.HOT, "unable to load klinklong.properties", e);
-    }
-
-    Set<Object> keys = properties.keySet();
-    for (Object object : keys) {
-      String key = (String) object;
-      setSystemProperty(key, properties.getProperty(key));
+    if (!loaded.get()) {
+      loadHomeProperties();
+      loadBuiltinProperties();
+      loaded.set(true);
     }
   }
 
@@ -37,6 +36,45 @@ public final class PropertyLoader {
     String actualValue = System.getProperty(propertyName);
     if (actualValue == null) {
       System.setProperty(propertyName, propertyValue);
+    }
+  }
+
+  static Path getUserHomePropertiesPath() {
+    return Paths.get(System.getProperty("user.home")).resolve(HOME_PROPERTY_FiLE_NAME);
+  }
+
+  static void allowReloading() {
+    loaded.set(false); // for testing purposes
+  }
+
+  private static void loadHomeProperties() {
+    File homeProperties = getUserHomePropertiesPath().toFile();
+    if (homeProperties.exists()) {
+      Properties properties = new Properties();
+      try (InputStream propertiesStream = new FileInputStream(homeProperties)) {
+        properties.load(propertiesStream);
+      } catch (Exception e) {
+        honk(HOT, "unable to load " + homeProperties.getAbsolutePath(), e);
+      }
+      applyProperties(properties);
+    }
+  }
+
+  private static void loadBuiltinProperties() {
+    Properties properties = new Properties();
+    try (InputStream propertiesStream = Horn.class.getResourceAsStream("/".concat(BUILTIN_PROPERTY_FILE_NAME))) {
+      properties.load(propertiesStream);
+    } catch (Exception e) {
+      honk(HOT, "unable to load builtin " + BUILTIN_PROPERTY_FILE_NAME, e);
+    }
+    applyProperties(properties);
+  }
+
+  private static void applyProperties(Properties properties) {
+    Set<Object> keys = properties.keySet();
+    for (Object object : keys) {
+      String key = (String) object;
+      setSystemProperty(key, properties.getProperty(key));
     }
   }
 

--- a/src/main/java/st/extreme/klingklong/util/PropertyLoader.java
+++ b/src/main/java/st/extreme/klingklong/util/PropertyLoader.java
@@ -1,0 +1,43 @@
+package st.extreme.klingklong.util;
+
+import static st.extreme.klingklong.util.Horn.honk;
+
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.Set;
+
+public final class PropertyLoader {
+
+  public static final String TEMPERATURE_PROPERTY_NAME = "st.extreme.klingklong.horn.temperature";
+
+
+  static {
+    loadProperties();
+  }
+
+  // TODO: handle properties in user.home
+
+  public static void loadProperties() {
+    Properties properties = new Properties();
+    try (InputStream propertiesStream = Horn.class.getResourceAsStream("/klingklong.properties")) {
+      properties.load(propertiesStream);
+    } catch (Exception e) {
+      honk(Temperature.HOT, "unable to load klinklong.properties", e);
+    }
+
+    Set<Object> keys = properties.keySet();
+    for (Object object : keys) {
+      String key = (String) object;
+      setSystemProperty(key, properties.getProperty(key));
+    }
+  }
+
+  static void setSystemProperty(String propertyName, String propertyValue) {
+    // if the system property is already set, do not overwrite it
+    String actualValue = System.getProperty(propertyName);
+    if (actualValue == null) {
+      System.setProperty(propertyName, propertyValue);
+    }
+  }
+
+}

--- a/src/main/resources/klingklong.properties
+++ b/src/main/resources/klingklong.properties
@@ -5,4 +5,4 @@
 # FROZEN: no honking (output) at all
 # COSY: informational output
 # HOT: every possible output
-klingklong.horn.temperature=COSY
+st.extreme.klingklong.horn.temperature=COSY

--- a/src/test/java/st/extreme/klingklong/IntegralCoverageTest.java
+++ b/src/test/java/st/extreme/klingklong/IntegralCoverageTest.java
@@ -2,6 +2,8 @@ package st.extreme.klingklong;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static st.extreme.klingklong.util.PropertyLoader.TEMPERATURE_PROPERTY_NAME;
+import static st.extreme.klingklong.util.Temperature.HOT;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -13,8 +15,6 @@ import org.junit.Test;
 import st.extreme.klingklong.demo.JVM1;
 import st.extreme.klingklong.demo.JVM2;
 import st.extreme.klingklong.util.HornFormatter;
-import st.extreme.klingklong.util.PropertyLoader;
-import st.extreme.klingklong.util.Temperature;
 import st.extreme.klingklong.util.TestFormattingListener;
 
 /**
@@ -29,7 +29,7 @@ public class IntegralCoverageTest {
 
   @Before
   public void setUp() {
-    originalTemeratureProperty = System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
+    originalTemeratureProperty = System.getProperty(TEMPERATURE_PROPERTY_NAME);
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
   }
@@ -37,16 +37,16 @@ public class IntegralCoverageTest {
   @After
   public void tearDown() {
     if (originalTemeratureProperty == null) {
-      System.getProperties().remove(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
+      System.getProperties().remove(TEMPERATURE_PROPERTY_NAME);
     } else {
-      System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+      System.setProperty(TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
     }
     HornFormatter.removeAllListeners();
   }
 
   @Test
   public void testTowEndpoints() throws InterruptedException {
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, HOT.name());
     WorkerThread1 workerThread1 = new WorkerThread1();
     WorkerThread2 workerThread2 = new WorkerThread2();
     workerThread1.start();
@@ -57,9 +57,8 @@ public class IntegralCoverageTest {
 
     List<String> formattedMessages = formattingListener.getFormattedMessages();
     assertTrue(formattedMessages.size() >= 24);
-    assertEquals(2, formattingListener.occurrences("starting worker on JVM"));
-    assertTrue(formattingListener.contains("creating kling"));
-    assertTrue(formattingListener.contains("creating klong"));
+    assertTrue(formattingListener.contains("creating kling for JVM worker"));
+    assertTrue(formattingListener.contains("creating klong for JVM worker"));
     assertEquals(2, formattingListener.occurrences("endpoint is connecting ..."));
     assertEquals(2, formattingListener.occurrences("endpoint is now connected"));
     assertEquals(2, formattingListener.occurrences("got a message: 'I am doing some work (0)'"));

--- a/src/test/java/st/extreme/klingklong/IntegralCoverageTest.java
+++ b/src/test/java/st/extreme/klingklong/IntegralCoverageTest.java
@@ -29,14 +29,18 @@ public class IntegralCoverageTest {
 
   @Before
   public void setUp() {
-    originalTemeratureProperty = System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
+    originalTemeratureProperty = System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME);
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
   }
 
   @After
   public void tearDown() {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+    if (originalTemeratureProperty == null) {
+      System.getProperties().remove(Horn.TEMPERATURE_PROPERTY_NAME);
+    } else {
+      System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+    }
     HornFormatter.removeAllListeners();
   }
 

--- a/src/test/java/st/extreme/klingklong/IntegralCoverageTest.java
+++ b/src/test/java/st/extreme/klingklong/IntegralCoverageTest.java
@@ -12,8 +12,8 @@ import org.junit.Test;
 
 import st.extreme.klingklong.demo.JVM1;
 import st.extreme.klingklong.demo.JVM2;
-import st.extreme.klingklong.util.Horn;
 import st.extreme.klingklong.util.HornFormatter;
+import st.extreme.klingklong.util.PropertyLoader;
 import st.extreme.klingklong.util.Temperature;
 import st.extreme.klingklong.util.TestFormattingListener;
 
@@ -29,7 +29,7 @@ public class IntegralCoverageTest {
 
   @Before
   public void setUp() {
-    originalTemeratureProperty = System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME);
+    originalTemeratureProperty = System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
   }
@@ -37,16 +37,16 @@ public class IntegralCoverageTest {
   @After
   public void tearDown() {
     if (originalTemeratureProperty == null) {
-      System.getProperties().remove(Horn.TEMPERATURE_PROPERTY_NAME);
+      System.getProperties().remove(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
     } else {
-      System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+      System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
     }
     HornFormatter.removeAllListeners();
   }
 
   @Test
   public void testTowEndpoints() throws InterruptedException {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
     WorkerThread1 workerThread1 = new WorkerThread1();
     WorkerThread2 workerThread2 = new WorkerThread2();
     workerThread1.start();

--- a/src/test/java/st/extreme/klingklong/IntegralTest.java
+++ b/src/test/java/st/extreme/klingklong/IntegralTest.java
@@ -2,6 +2,8 @@ package st.extreme.klingklong;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static st.extreme.klingklong.util.PropertyLoader.TEMPERATURE_PROPERTY_NAME;
+import static st.extreme.klingklong.util.Temperature.HOT;
 
 import java.io.File;
 import java.net.URL;
@@ -18,7 +20,6 @@ import org.junit.Test;
 
 import st.extreme.klingklong.util.Horn;
 import st.extreme.klingklong.util.PropertyLoader;
-import st.extreme.klingklong.util.Temperature;
 
 /**
  * Test a real life situation: start up two virtual machines and let them talk to each other
@@ -41,7 +42,7 @@ public class IntegralTest {
   @Before
   public void setUp() throws Exception {
     // determine class path elements for the subprocesses
-    URL propertiesURL = Horn.class.getResource("/klingklong.properties");
+    URL propertiesURL = Horn.class.getResource("/".concat(PropertyLoader.BUILTIN_PROPERTY_FILE_NAME));
     assertNotNull(propertiesURL);
     Path propertiesPath = Paths.get(propertiesURL.toURI());
     Path parentPath = propertiesPath.getParent();
@@ -94,7 +95,7 @@ public class IntegralTest {
     ProcessBuilder processBuilder = new ProcessBuilder();
     processBuilder.redirectOutput(processConfig.getOutputPath().toFile());
     processBuilder.redirectErrorStream(true);
-    String temperatureProperty = "-D".concat(PropertyLoader.TEMPERATURE_PROPERTY_NAME).concat("=").concat(Temperature.HOT.name());
+    String temperatureProperty = "-D".concat(TEMPERATURE_PROPERTY_NAME).concat("=").concat(HOT.name());
     String classpath = resourcesPath.toString().concat(File.pathSeparator) //
         .concat(mainPath.toString()).concat(File.pathSeparator) //
         .concat(testPath.toString());
@@ -109,10 +110,6 @@ public class IntegralTest {
     assertTrue("expected at least 11 lines, but only got " + lines.size() + ":\n" + lines, lines.size() >= 11);
 
     int index = 0;
-    line = lines.get(index);
-    assertTrue(line.contains("starting worker on JVM"));
-
-    index++;
     line = lines.get(index);
     assertTrue(line.contains("creating kling") || line.contains("creating klong"));
     index++;

--- a/src/test/java/st/extreme/klingklong/IntegralTest.java
+++ b/src/test/java/st/extreme/klingklong/IntegralTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import st.extreme.klingklong.util.Horn;
+import st.extreme.klingklong.util.PropertyLoader;
 import st.extreme.klingklong.util.Temperature;
 
 /**
@@ -93,7 +94,7 @@ public class IntegralTest {
     ProcessBuilder processBuilder = new ProcessBuilder();
     processBuilder.redirectOutput(processConfig.getOutputPath().toFile());
     processBuilder.redirectErrorStream(true);
-    String temperatureProperty = "-D".concat(Horn.TEMPERATURE_PROPERTY_NAME).concat("=").concat(Temperature.HOT.name());
+    String temperatureProperty = "-D".concat(PropertyLoader.TEMPERATURE_PROPERTY_NAME).concat("=").concat(Temperature.HOT.name());
     String classpath = resourcesPath.toString().concat(File.pathSeparator) //
         .concat(mainPath.toString()).concat(File.pathSeparator) //
         .concat(testPath.toString());

--- a/src/test/java/st/extreme/klingklong/ReceiverImplTest.java
+++ b/src/test/java/st/extreme/klingklong/ReceiverImplTest.java
@@ -2,6 +2,8 @@ package st.extreme.klingklong;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static st.extreme.klingklong.util.PropertyLoader.TEMPERATURE_PROPERTY_NAME;
+import static st.extreme.klingklong.util.Temperature.HOT;
 
 import java.net.ServerSocket;
 import java.util.concurrent.Semaphore;
@@ -11,8 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import st.extreme.klingklong.util.HornFormatter;
-import st.extreme.klingklong.util.PropertyLoader;
-import st.extreme.klingklong.util.Temperature;
 import st.extreme.klingklong.util.TestFormattingListener;
 
 public class ReceiverImplTest {
@@ -22,8 +22,8 @@ public class ReceiverImplTest {
 
   @Before
   public void setUp() {
-    originalTemeratureProperty = System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
+    originalTemeratureProperty = System.getProperty(TEMPERATURE_PROPERTY_NAME);
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, HOT.name());
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
   }
@@ -31,9 +31,9 @@ public class ReceiverImplTest {
   @After
   public void tearDown() {
     if (originalTemeratureProperty == null) {
-      System.getProperties().remove(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
+      System.getProperties().remove(TEMPERATURE_PROPERTY_NAME);
     } else {
-      System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+      System.setProperty(TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
     }
     HornFormatter.removeAllListeners();
   }

--- a/src/test/java/st/extreme/klingklong/ReceiverImplTest.java
+++ b/src/test/java/st/extreme/klingklong/ReceiverImplTest.java
@@ -22,7 +22,7 @@ public class ReceiverImplTest {
 
   @Before
   public void setUp() {
-    originalTemeratureProperty = System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
+    originalTemeratureProperty = System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME);
     System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
@@ -30,7 +30,11 @@ public class ReceiverImplTest {
 
   @After
   public void tearDown() {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+    if (originalTemeratureProperty == null) {
+      System.getProperties().remove(Horn.TEMPERATURE_PROPERTY_NAME);
+    } else {
+      System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+    }
     HornFormatter.removeAllListeners();
   }
 

--- a/src/test/java/st/extreme/klingklong/ReceiverImplTest.java
+++ b/src/test/java/st/extreme/klingklong/ReceiverImplTest.java
@@ -10,8 +10,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import st.extreme.klingklong.util.Horn;
 import st.extreme.klingklong.util.HornFormatter;
+import st.extreme.klingklong.util.PropertyLoader;
 import st.extreme.klingklong.util.Temperature;
 import st.extreme.klingklong.util.TestFormattingListener;
 
@@ -22,8 +22,8 @@ public class ReceiverImplTest {
 
   @Before
   public void setUp() {
-    originalTemeratureProperty = System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME);
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
+    originalTemeratureProperty = System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
   }
@@ -31,9 +31,9 @@ public class ReceiverImplTest {
   @After
   public void tearDown() {
     if (originalTemeratureProperty == null) {
-      System.getProperties().remove(Horn.TEMPERATURE_PROPERTY_NAME);
+      System.getProperties().remove(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
     } else {
-      System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+      System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
     }
     HornFormatter.removeAllListeners();
   }

--- a/src/test/java/st/extreme/klingklong/SenderImplTest.java
+++ b/src/test/java/st/extreme/klingklong/SenderImplTest.java
@@ -10,8 +10,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import st.extreme.klingklong.util.Horn;
 import st.extreme.klingklong.util.HornFormatter;
+import st.extreme.klingklong.util.PropertyLoader;
 import st.extreme.klingklong.util.Temperature;
 import st.extreme.klingklong.util.TestFormattingListener;
 
@@ -22,8 +22,8 @@ public class SenderImplTest {
 
   @Before
   public void setUp() {
-    originalTemeratureProperty = System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME);
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
+    originalTemeratureProperty = System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
   }
@@ -31,9 +31,9 @@ public class SenderImplTest {
   @After
   public void tearDown() {
     if (originalTemeratureProperty == null) {
-      System.getProperties().remove(Horn.TEMPERATURE_PROPERTY_NAME);
+      System.getProperties().remove(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
     } else {
-      System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+      System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
     }
     HornFormatter.removeAllListeners();
   }

--- a/src/test/java/st/extreme/klingklong/SenderImplTest.java
+++ b/src/test/java/st/extreme/klingklong/SenderImplTest.java
@@ -1,6 +1,8 @@
 package st.extreme.klingklong;
 
 import static org.junit.Assert.assertTrue;
+import static st.extreme.klingklong.util.PropertyLoader.TEMPERATURE_PROPERTY_NAME;
+import static st.extreme.klingklong.util.Temperature.HOT;
 
 import java.net.InetAddress;
 import java.util.concurrent.Semaphore;
@@ -11,8 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import st.extreme.klingklong.util.HornFormatter;
-import st.extreme.klingklong.util.PropertyLoader;
-import st.extreme.klingklong.util.Temperature;
 import st.extreme.klingklong.util.TestFormattingListener;
 
 public class SenderImplTest {
@@ -22,8 +22,8 @@ public class SenderImplTest {
 
   @Before
   public void setUp() {
-    originalTemeratureProperty = System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
+    originalTemeratureProperty = System.getProperty(TEMPERATURE_PROPERTY_NAME);
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, HOT.name());
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
   }
@@ -31,9 +31,9 @@ public class SenderImplTest {
   @After
   public void tearDown() {
     if (originalTemeratureProperty == null) {
-      System.getProperties().remove(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
+      System.getProperties().remove(TEMPERATURE_PROPERTY_NAME);
     } else {
-      System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+      System.setProperty(TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
     }
     HornFormatter.removeAllListeners();
   }

--- a/src/test/java/st/extreme/klingklong/SenderImplTest.java
+++ b/src/test/java/st/extreme/klingklong/SenderImplTest.java
@@ -22,7 +22,7 @@ public class SenderImplTest {
 
   @Before
   public void setUp() {
-    originalTemeratureProperty = System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
+    originalTemeratureProperty = System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME);
     System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
@@ -30,7 +30,11 @@ public class SenderImplTest {
 
   @After
   public void tearDown() {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+    if (originalTemeratureProperty == null) {
+      System.getProperties().remove(Horn.TEMPERATURE_PROPERTY_NAME);
+    } else {
+      System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+    }
     HornFormatter.removeAllListeners();
   }
 

--- a/src/test/java/st/extreme/klingklong/util/HornTest.java
+++ b/src/test/java/st/extreme/klingklong/util/HornTest.java
@@ -5,63 +5,39 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class HornTest {
-
-  private Path originalPropertiesPath;
-  private List<String> originalLines;
-  private String originalTemeratureProperty;
   private TestFormattingListener formattingListener;
 
   @Before
   public void setUp() throws Exception {
-    URL originalPropertiesURL = Horn.class.getResource("/klingklong.properties");
-    assertNotNull(originalPropertiesURL);
-    originalPropertiesPath = Paths.get(originalPropertiesURL.toURI());
-    originalLines = Files.readAllLines(originalPropertiesPath);
-    originalTemeratureProperty = System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME);
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
   }
 
   @After
   public void tearDown() throws Exception {
-    if (originalTemeratureProperty == null) {
-      System.getProperties().remove(Horn.TEMPERATURE_PROPERTY_NAME);
-    } else {
-      System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
-    }
     HornFormatter.removeAllListeners();
-    Files.write(originalPropertiesPath, originalLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
   }
 
   @Test
   public void testSystemTemperature() {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
     assertEquals(Temperature.FROZEN, Horn.systemTemperature());
 
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.COSY.name());
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.COSY.name());
     assertEquals(Temperature.COSY, Horn.systemTemperature());
 
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
     assertEquals(Temperature.HOT, Horn.systemTemperature());
   }
 
   @Test
   public void testHonk_accept_HOT() {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
     Horn.honk(Temperature.HOT, "hot message");
     assertTrue(formattingListener.contains("hot message"));
     Horn.honk(Temperature.COSY, "cosy message");
@@ -72,7 +48,7 @@ public class HornTest {
 
   @Test
   public void testHonk_accept_COSY() {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.COSY.name());
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.COSY.name());
     Horn.honk(Temperature.HOT, "hot message");
     assertFalse(formattingListener.contains("hot message"));
     Horn.honk(Temperature.COSY, "cosy message");
@@ -83,7 +59,7 @@ public class HornTest {
 
   @Test
   public void testHonk_accept_FROZEN() {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
     Horn.honk(Temperature.HOT, "hot message");
     assertFalse(formattingListener.contains("hot message"));
     Horn.honk(Temperature.COSY, "cosy message");
@@ -94,7 +70,7 @@ public class HornTest {
 
   @Test
   public void testHonkThrowable() {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.COSY.name());
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.COSY.name());
     Horn.honk(Temperature.COSY, "a message with an exception", new Exception("the exception"));
     String expectedStart = "[klingklong] a message with an exception:\n" + //
         "[klingklong] java.lang.Exception: the exception\n" + //
@@ -107,59 +83,6 @@ public class HornTest {
   @Test
   public void testCreation() {
     assertNotNull(new Horn()); // coverage, we salute you
-  }
-
-  @Test
-  public void testLoadProperties() throws IOException {
-    Horn.loadProperties();
-    assertEquals(Temperature.COSY.name(), System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME));
-  }
-
-  @Test
-  public void testLoadProperties_HOT() throws IOException {
-    List<String> newLines = new ArrayList<>();
-    originalLines.forEach(line -> {
-      if (line.startsWith(Horn.TEMPERATURE_PROPERTY_NAME)) {
-        line = Horn.TEMPERATURE_PROPERTY_NAME.concat("=").concat(Temperature.HOT.name());
-      }
-      newLines.add(line);
-    });
-    assertEquals(originalLines.size(), newLines.size());
-    Files.write(originalPropertiesPath, newLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
-    Horn.loadProperties();
-    assertEquals(Temperature.HOT.name(), System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME));
-  }
-
-  @Test
-  public void testLoadProperties_System_before_builtin() {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
-    Horn.loadProperties();
-    assertEquals(Temperature.FROZEN.name(), System.getProperty(Horn.TEMPERATURE_PROPERTY_NAME));
-  }
-
-  @Test
-  public void testLoadProperties_Exception() throws Exception {
-    System.setProperty(Horn.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
-    List<String> newLines = new ArrayList<>();
-    originalLines.forEach(line -> newLines.add(line));
-    assertEquals(originalLines.size(), newLines.size());
-    newLines.add("test.breaking.property=\\u2");
-    Files.write(originalPropertiesPath, newLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
-    Horn.loadProperties();
-    assertTrue(formattingListener.contains("unable to load klinklong.properties"));
-  }
-
-  @Test
-  public void testSetSystemProperty() {
-    final String testSystemProperetyName = "st.extreme.klingklong.test.property";
-    try {
-      Horn.setSystemProperty(testSystemProperetyName, "initial");
-      assertEquals("initial", System.getProperty(testSystemProperetyName));
-      Horn.setSystemProperty(testSystemProperetyName, "overwrite");
-      assertEquals("initial", System.getProperty(testSystemProperetyName));
-    } finally {
-      System.getProperties().remove(testSystemProperetyName);
-    }
   }
 
 }

--- a/src/test/java/st/extreme/klingklong/util/HornTest.java
+++ b/src/test/java/st/extreme/klingklong/util/HornTest.java
@@ -4,6 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static st.extreme.klingklong.util.PropertyLoader.TEMPERATURE_PROPERTY_NAME;
+import static st.extreme.klingklong.util.Temperature.COSY;
+import static st.extreme.klingklong.util.Temperature.FROZEN;
+import static st.extreme.klingklong.util.Temperature.HOT;
 
 import org.junit.After;
 import org.junit.Before;
@@ -25,53 +29,53 @@ public class HornTest {
 
   @Test
   public void testSystemTemperature() {
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
-    assertEquals(Temperature.FROZEN, Horn.systemTemperature());
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, FROZEN.name());
+    assertEquals(FROZEN, Horn.systemTemperature());
 
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.COSY.name());
-    assertEquals(Temperature.COSY, Horn.systemTemperature());
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, COSY.name());
+    assertEquals(COSY, Horn.systemTemperature());
 
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
-    assertEquals(Temperature.HOT, Horn.systemTemperature());
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, HOT.name());
+    assertEquals(HOT, Horn.systemTemperature());
   }
 
   @Test
   public void testHonk_accept_HOT() {
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
-    Horn.honk(Temperature.HOT, "hot message");
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, HOT.name());
+    Horn.honk(HOT, "hot message");
     assertTrue(formattingListener.contains("hot message"));
-    Horn.honk(Temperature.COSY, "cosy message");
+    Horn.honk(COSY, "cosy message");
     assertTrue(formattingListener.contains("cosy message"));
-    Horn.honk(Temperature.FROZEN, "frozen message");
+    Horn.honk(FROZEN, "frozen message");
     assertFalse(formattingListener.contains("frozen message"));
   }
 
   @Test
   public void testHonk_accept_COSY() {
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.COSY.name());
-    Horn.honk(Temperature.HOT, "hot message");
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, COSY.name());
+    Horn.honk(HOT, "hot message");
     assertFalse(formattingListener.contains("hot message"));
-    Horn.honk(Temperature.COSY, "cosy message");
+    Horn.honk(COSY, "cosy message");
     assertTrue(formattingListener.contains("cosy message"));
-    Horn.honk(Temperature.FROZEN, "frozen message");
+    Horn.honk(FROZEN, "frozen message");
     assertFalse(formattingListener.contains("frozen message"));
   }
 
   @Test
   public void testHonk_accept_FROZEN() {
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
-    Horn.honk(Temperature.HOT, "hot message");
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, FROZEN.name());
+    Horn.honk(HOT, "hot message");
     assertFalse(formattingListener.contains("hot message"));
-    Horn.honk(Temperature.COSY, "cosy message");
+    Horn.honk(COSY, "cosy message");
     assertFalse(formattingListener.contains("cosy message"));
-    Horn.honk(Temperature.FROZEN, "frozen message");
+    Horn.honk(FROZEN, "frozen message");
     assertFalse(formattingListener.contains("frozen message"));
   }
 
   @Test
   public void testHonkThrowable() {
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.COSY.name());
-    Horn.honk(Temperature.COSY, "a message with an exception", new Exception("the exception"));
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, COSY.name());
+    Horn.honk(COSY, "a message with an exception", new Exception("the exception"));
     String expectedStart = "[klingklong] a message with an exception:\n" + //
         "[klingklong] java.lang.Exception: the exception\n" + //
         "\tat st.extreme.klingklong.util.HornTest.testHonkThrowable(";

--- a/src/test/java/st/extreme/klingklong/util/PropertyLoaderTest.java
+++ b/src/test/java/st/extreme/klingklong/util/PropertyLoaderTest.java
@@ -1,0 +1,107 @@
+package st.extreme.klingklong.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PropertyLoaderTest {
+
+  private Path originalPropertiesPath;
+  private List<String> originalLines;
+  private String originalTemeratureProperty;
+  private TestFormattingListener formattingListener;
+
+  @Before
+  public void setUp() throws Exception {
+    URL originalPropertiesURL = PropertyLoader.class.getResource("/klingklong.properties");
+    assertNotNull(originalPropertiesURL);
+    originalPropertiesPath = Paths.get(originalPropertiesURL.toURI());
+    originalLines = Files.readAllLines(originalPropertiesPath);
+    originalTemeratureProperty = System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
+    formattingListener = new TestFormattingListener();
+    HornFormatter.addFormattingListener(formattingListener);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (originalTemeratureProperty == null) {
+      System.getProperties().remove(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
+    } else {
+      System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+    }
+    Files.write(originalPropertiesPath, originalLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    HornFormatter.removeAllListeners();
+  }
+
+  @Test
+  public void testCreation() {
+    assertNotNull(new PropertyLoader()); // coverage, we salute you
+  }
+
+  @Test
+  public void testLoadProperties() throws IOException {
+    PropertyLoader.loadProperties();
+    assertEquals(Temperature.COSY.name(), System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME));
+  }
+
+  @Test
+  public void testLoadProperties_HOT() throws IOException {
+    List<String> newLines = new ArrayList<>();
+    originalLines.forEach(line -> {
+      if (line.startsWith(PropertyLoader.TEMPERATURE_PROPERTY_NAME)) {
+        line = PropertyLoader.TEMPERATURE_PROPERTY_NAME.concat("=").concat(Temperature.HOT.name());
+      }
+      newLines.add(line);
+    });
+    assertEquals(originalLines.size(), newLines.size());
+    Files.write(originalPropertiesPath, newLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    PropertyLoader.loadProperties();
+    assertEquals(Temperature.HOT.name(), System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME));
+  }
+
+  @Test
+  public void testLoadProperties_System_before_builtin() {
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
+    PropertyLoader.loadProperties();
+    assertEquals(Temperature.FROZEN.name(), System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME));
+  }
+
+  @Test
+  public void testLoadProperties_Exception() throws Exception {
+    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
+    List<String> newLines = new ArrayList<>();
+    originalLines.forEach(line -> newLines.add(line));
+    assertEquals(originalLines.size(), newLines.size());
+    newLines.add("test.breaking.property=\\u2");
+    Files.write(originalPropertiesPath, newLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    PropertyLoader.loadProperties();
+    assertTrue(formattingListener.contains("unable to load klinklong.properties"));
+  }
+
+  @Test
+  public void testSetSystemProperty() {
+    final String testSystemProperetyName = "st.extreme.klingklong.test.property";
+    try {
+      PropertyLoader.setSystemProperty(testSystemProperetyName, "initial");
+      assertEquals("initial", System.getProperty(testSystemProperetyName));
+      PropertyLoader.setSystemProperty(testSystemProperetyName, "overwrite");
+      assertEquals("initial", System.getProperty(testSystemProperetyName));
+    } finally {
+      System.getProperties().remove(testSystemProperetyName);
+    }
+  }
+
+}

--- a/src/test/java/st/extreme/klingklong/util/PropertyLoaderTest.java
+++ b/src/test/java/st/extreme/klingklong/util/PropertyLoaderTest.java
@@ -3,10 +3,16 @@ package st.extreme.klingklong.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static st.extreme.klingklong.util.PropertyLoader.BUILTIN_PROPERTY_FILE_NAME;
+import static st.extreme.klingklong.util.PropertyLoader.TEMPERATURE_PROPERTY_NAME;
+import static st.extreme.klingklong.util.Temperature.COSY;
+import static st.extreme.klingklong.util.Temperature.FROZEN;
+import static st.extreme.klingklong.util.Temperature.HOT;
 
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
@@ -19,89 +25,135 @@ import org.junit.Test;
 
 public class PropertyLoaderTest {
 
-  private Path originalPropertiesPath;
-  private List<String> originalLines;
+  private Path originalBuiltinPropertiesPath;
+  private List<String> originalBuiltinLines;
+  private List<String> originalHomeLines;
   private String originalTemeratureProperty;
   private TestFormattingListener formattingListener;
 
   @Before
   public void setUp() throws Exception {
-    URL originalPropertiesURL = PropertyLoader.class.getResource("/klingklong.properties");
+    originalTemeratureProperty = System.getProperty(TEMPERATURE_PROPERTY_NAME);
+    URL originalPropertiesURL = PropertyLoader.class.getResource("/".concat(BUILTIN_PROPERTY_FILE_NAME));
     assertNotNull(originalPropertiesURL);
-    originalPropertiesPath = Paths.get(originalPropertiesURL.toURI());
-    originalLines = Files.readAllLines(originalPropertiesPath);
-    originalTemeratureProperty = System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
+    originalBuiltinPropertiesPath = Paths.get(originalPropertiesURL.toURI());
+    originalBuiltinLines = Files.readAllLines(originalBuiltinPropertiesPath);
+    try {
+      originalHomeLines = Files.readAllLines(PropertyLoader.getUserHomePropertiesPath());
+    } catch (NoSuchFileException e) {
+      originalHomeLines = new ArrayList<>();
+    }
     formattingListener = new TestFormattingListener();
     HornFormatter.addFormattingListener(formattingListener);
+    // start with no system properties at all
+    if (!"unset".equals(System.getProperty(TEMPERATURE_PROPERTY_NAME, "unset"))) {
+      System.getProperties().remove(TEMPERATURE_PROPERTY_NAME);
+    }
+    PropertyLoader.allowReloading();
   }
 
   @After
   public void tearDown() throws Exception {
     if (originalTemeratureProperty == null) {
-      System.getProperties().remove(PropertyLoader.TEMPERATURE_PROPERTY_NAME);
+      System.getProperties().remove(TEMPERATURE_PROPERTY_NAME);
     } else {
-      System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
+      System.setProperty(TEMPERATURE_PROPERTY_NAME, originalTemeratureProperty);
     }
-    Files.write(originalPropertiesPath, originalLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    Files.write(originalBuiltinPropertiesPath, originalBuiltinLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    if (originalHomeLines.size() > 0) {
+      Files.write(PropertyLoader.getUserHomePropertiesPath(), originalHomeLines, StandardOpenOption.WRITE,
+          StandardOpenOption.TRUNCATE_EXISTING);
+    } else {
+      Files.deleteIfExists(PropertyLoader.getUserHomePropertiesPath());
+    }
     HornFormatter.removeAllListeners();
-  }
-
-  @Test
-  public void testCreation() {
-    assertNotNull(new PropertyLoader()); // coverage, we salute you
   }
 
   @Test
   public void testLoadProperties() throws IOException {
     PropertyLoader.loadProperties();
-    assertEquals(Temperature.COSY.name(), System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME));
+    assertEquals(COSY.name(), System.getProperty(TEMPERATURE_PROPERTY_NAME));
   }
 
   @Test
   public void testLoadProperties_HOT() throws IOException {
     List<String> newLines = new ArrayList<>();
-    originalLines.forEach(line -> {
-      if (line.startsWith(PropertyLoader.TEMPERATURE_PROPERTY_NAME)) {
-        line = PropertyLoader.TEMPERATURE_PROPERTY_NAME.concat("=").concat(Temperature.HOT.name());
+    originalBuiltinLines.forEach(line -> {
+      if (line.startsWith(TEMPERATURE_PROPERTY_NAME)) {
+        line = TEMPERATURE_PROPERTY_NAME.concat("=").concat(HOT.name());
       }
       newLines.add(line);
     });
-    assertEquals(originalLines.size(), newLines.size());
-    Files.write(originalPropertiesPath, newLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    assertEquals(originalBuiltinLines.size(), newLines.size());
+    Files.write(originalBuiltinPropertiesPath, newLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
     PropertyLoader.loadProperties();
-    assertEquals(Temperature.HOT.name(), System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME));
+    assertEquals(HOT.name(), System.getProperty(TEMPERATURE_PROPERTY_NAME));
   }
 
   @Test
-  public void testLoadProperties_System_before_builtin() {
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.FROZEN.name());
+  public void testLoadProperties_System_before_Builtin() {
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, FROZEN.name());
     PropertyLoader.loadProperties();
-    assertEquals(Temperature.FROZEN.name(), System.getProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME));
+    assertEquals(FROZEN.name(), System.getProperty(TEMPERATURE_PROPERTY_NAME));
   }
 
   @Test
-  public void testLoadProperties_Exception() throws Exception {
-    System.setProperty(PropertyLoader.TEMPERATURE_PROPERTY_NAME, Temperature.HOT.name());
+  public void testLoadProperties_Builtin_Exception() throws Exception {
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, HOT.name());
     List<String> newLines = new ArrayList<>();
-    originalLines.forEach(line -> newLines.add(line));
-    assertEquals(originalLines.size(), newLines.size());
+    originalBuiltinLines.forEach(line -> newLines.add(line));
+    assertEquals(originalBuiltinLines.size(), newLines.size());
     newLines.add("test.breaking.property=\\u2");
-    Files.write(originalPropertiesPath, newLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    Files.write(originalBuiltinPropertiesPath, newLines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
     PropertyLoader.loadProperties();
-    assertTrue(formattingListener.contains("unable to load klinklong.properties"));
+    assertTrue(formattingListener.contains("unable to load builtin klingklong.properties:"));
+  }
+
+  @Test
+  public void testLoadProperties_Home_Exception() throws Exception {
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, HOT.name());
+    List<String> newLines = new ArrayList<>();
+    newLines.add("test.breaking.property=\\u2");
+    Files.write(PropertyLoader.getUserHomePropertiesPath(), newLines, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+    PropertyLoader.loadProperties();
+    assertTrue(formattingListener.contains("unable to load " + PropertyLoader.getUserHomePropertiesPath().toString()));
+  }
+
+  @Test
+  public void testLoadProperties_Home_before_Builtin() throws Exception {
+    List<String> homeLines = new ArrayList<>();
+    homeLines.add(TEMPERATURE_PROPERTY_NAME.concat("=").concat(HOT.name()));
+    Files.write(PropertyLoader.getUserHomePropertiesPath(), homeLines, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+    PropertyLoader.loadProperties();
+    assertEquals(HOT.name(), System.getProperty(TEMPERATURE_PROPERTY_NAME));
+  }
+
+  @Test
+  public void testLoadProperties_System_before_Home() throws Exception {
+    System.setProperty(TEMPERATURE_PROPERTY_NAME, FROZEN.name());
+    List<String> homeLines = new ArrayList<>();
+    homeLines.add(TEMPERATURE_PROPERTY_NAME.concat("=").concat(HOT.name()));
+    Files.write(PropertyLoader.getUserHomePropertiesPath(), homeLines, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+    PropertyLoader.loadProperties();
+    assertEquals(FROZEN.name(), System.getProperty(TEMPERATURE_PROPERTY_NAME));
   }
 
   @Test
   public void testSetSystemProperty() {
-    final String testSystemProperetyName = "st.extreme.klingklong.test.property";
+    final String testSystemPropertyName = "st.extreme.klingklong.test.property";
     try {
-      PropertyLoader.setSystemProperty(testSystemProperetyName, "initial");
-      assertEquals("initial", System.getProperty(testSystemProperetyName));
-      PropertyLoader.setSystemProperty(testSystemProperetyName, "overwrite");
-      assertEquals("initial", System.getProperty(testSystemProperetyName));
+      PropertyLoader.setSystemProperty(testSystemPropertyName, "initial");
+      assertEquals("initial", System.getProperty(testSystemPropertyName));
+      PropertyLoader.setSystemProperty(testSystemPropertyName, "overwrite");
+      assertEquals("initial", System.getProperty(testSystemPropertyName));
     } finally {
-      System.getProperties().remove(testSystemProperetyName);
+      System.getProperties().remove(testSystemPropertyName);
     }
+  }
+
+  @Test
+  public void testCreation() {
+    assertNotNull(new PropertyLoader()); // coverage, we salute you
   }
 
 }

--- a/src/test/java/st/extreme/klingklong/util/TemperatureTest.java
+++ b/src/test/java/st/extreme/klingklong/util/TemperatureTest.java
@@ -3,6 +3,9 @@ package st.extreme.klingklong.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static st.extreme.klingklong.util.Temperature.COSY;
+import static st.extreme.klingklong.util.Temperature.FROZEN;
+import static st.extreme.klingklong.util.Temperature.HOT;
 
 import org.junit.Test;
 
@@ -10,28 +13,28 @@ public class TemperatureTest {
 
   @Test
   public void testTemperatureValueOf() {
-    assertEquals(Temperature.FROZEN, Temperature.valueOf("FROZEN"));
-    assertEquals(Temperature.COSY, Temperature.valueOf("COSY"));
-    assertEquals(Temperature.HOT, Temperature.valueOf("HOT"));
+    assertEquals(FROZEN, Temperature.valueOf("FROZEN"));
+    assertEquals(COSY, Temperature.valueOf("COSY"));
+    assertEquals(HOT, Temperature.valueOf("HOT"));
   }
 
   @Test
   public void testBelowOrEqualTo() {
-    assertTrue(Temperature.FROZEN.isBelowOrEqualTo(Temperature.FROZEN));
-    assertTrue(Temperature.FROZEN.isBelowOrEqualTo(Temperature.COSY));
-    assertTrue(Temperature.FROZEN.isBelowOrEqualTo(Temperature.HOT));
+    assertTrue(FROZEN.isBelowOrEqualTo(FROZEN));
+    assertTrue(FROZEN.isBelowOrEqualTo(COSY));
+    assertTrue(FROZEN.isBelowOrEqualTo(HOT));
 
-    assertFalse(Temperature.COSY.isBelowOrEqualTo(Temperature.FROZEN));
-    assertTrue(Temperature.COSY.isBelowOrEqualTo(Temperature.COSY));
-    assertTrue(Temperature.COSY.isBelowOrEqualTo(Temperature.HOT));
+    assertFalse(COSY.isBelowOrEqualTo(FROZEN));
+    assertTrue(COSY.isBelowOrEqualTo(COSY));
+    assertTrue(COSY.isBelowOrEqualTo(HOT));
 
-    assertFalse(Temperature.HOT.isBelowOrEqualTo(Temperature.FROZEN));
-    assertFalse(Temperature.HOT.isBelowOrEqualTo(Temperature.COSY));
-    assertTrue(Temperature.HOT.isBelowOrEqualTo(Temperature.HOT));
+    assertFalse(HOT.isBelowOrEqualTo(FROZEN));
+    assertFalse(HOT.isBelowOrEqualTo(COSY));
+    assertTrue(HOT.isBelowOrEqualTo(HOT));
 
-    assertFalse(Temperature.FROZEN.isBelowOrEqualTo(null));
-    assertFalse(Temperature.COSY.isBelowOrEqualTo(null));
-    assertFalse(Temperature.HOT.isBelowOrEqualTo(null));
+    assertFalse(FROZEN.isBelowOrEqualTo(null));
+    assertFalse(COSY.isBelowOrEqualTo(null));
+    assertFalse(HOT.isBelowOrEqualTo(null));
   }
 
 }


### PR DESCRIPTION
Properties now have the following precedence:

1. If a `System` property is set, e.g. by passing it with a `-D` argument to the JVM, it overrides all other occurrences of the same property.
2. If a property is set in `user.home/.st.extreme.klingklong.properties`, it overrides the builtin default. `user.home` is determined by calling `System.getProperty("user.home")`.
3. If the property is not set in the above mentioned two locations, the builtin default value is used. 